### PR TITLE
Heroku

### DIFF
--- a/app/models/trump_admin_debts/base.rb
+++ b/app/models/trump_admin_debts/base.rb
@@ -1,7 +1,5 @@
 module TrumpAdminDebts
   class Base < ActiveRecord::Base
     self.abstract_class = true
-
-    establish_connection('trump_admin_debts_db')
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -79,7 +79,5 @@ test:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
 production:
-  <<: *default
-  database: chartable_production
-  username: chartable
-  password: <%= ENV['CHARTABLE_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
This is where we removed an establish_connection call to a db that no longer exists (holdover from earlier incarnation of the project), which was causing heroku deployment to break.